### PR TITLE
Fix spelling error in team role

### DIFF
--- a/src/app/our-team/page.tsx
+++ b/src/app/our-team/page.tsx
@@ -25,7 +25,7 @@ export default function OurTeamPage() {
     },
     {
       name: translations[language].teamWilliamName ?? 'William Lu',
-      role: translations[language].teamWilliamRole ?? 'Principle Carbon Consultant',
+      role: translations[language].teamWilliamRole ?? 'Principal Carbon Consultant',
       education: translations[language].teamWilliamEducation ?? 'M.S. in Occupational Safety and Health, China Medical University',
       headshot: '/img/team/william-color.jpg',
       headshotColor: '/img/team/william-color.jpg',

--- a/src/components/LanguageProvider.tsx
+++ b/src/components/LanguageProvider.tsx
@@ -150,7 +150,7 @@ export const translations = {
     teamStephenBio: "Former Bloomberg AI engineering manager now helping businesses reach net‑zero.",
 
     teamWilliamName: "William Lu",
-    teamWilliamRole: "Principle Carbon Consultant",
+    teamWilliamRole: "Principal Carbon Consultant",
     teamWilliamBio: "Experienced carbon management consultant with a decade of expertise in GHG inventories and carbon strategies.",
     teamWilliamEducation: "M.S. in Occupational Safety and Health, China Medical University",
 


### PR DESCRIPTION
## Summary
- fix typo for William's role in translations
- update fallback text in Our Team page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408cb9af488321909bda2b7278bf85