### PR TITLE
Fix upload status update logic

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -58,10 +58,11 @@ export default function UploadPage() {
     });
 
     setErrors((prev) => [...prev, ...newErrors]);
-    setFiles((prev) => [...prev, ...newFiles]);
-    setStatus((prev) =>
-      [...prev, ...newFiles].length ? 'ready' : prev
-    );
+    setFiles((prev) => {
+      const updated = [...prev, ...newFiles];
+      setStatus((prevStatus) => (updated.length ? 'ready' : prevStatus));
+      return updated;
+    });
   }
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
## Summary
- update status when adding files based on new file count

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409750727c832193020df973242c2b