### PR TITLE
Fix removeFile logic

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -75,10 +75,11 @@ export default function UploadPage() {
   }
 
   function removeFile(index: number) {
-    setFiles(prev => prev.filter((_, i) => i !== index));
-    if (files.length === 1) {
-      setStatus('idle');
-    }
+    setFiles(prev => {
+      const updated = prev.filter((_, i) => i !== index);
+      if (!updated.length) setStatus('idle');
+      return updated;
+    });
   }
 
   function clearErrors() {


### PR DESCRIPTION
## Summary
- adjust `removeFile` to compute remaining files before resetting status

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840975244d08321b7361f1f79623d18