### PR TITLE
Fix handleUpload fetch errors

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -90,15 +90,25 @@ export default function UploadPage() {
 
     setStatus('uploading');
 
+    const newErrors: string[] = [];
+
     for (const f of files) {
       const fd = new FormData();
       fd.append('file', f, f.name);
 
-      const res = await fetch('/api/upload', { method: 'POST', body: fd });
-      if (!res.ok) {
-        const { error } = await res.json().catch(() => ({ error: '上傳失敗' }));
-        setErrors(prev => [...prev, `${f.name}: ${error}`]);
+      try {
+        const res = await fetch('/api/upload', { method: 'POST', body: fd });
+        if (!res.ok) {
+          const { error } = await res.json().catch(() => ({ error: '上傳失敗' }));
+          newErrors.push(`${f.name}: ${error}`);
+        }
+      } catch (err) {
+        newErrors.push(`${f.name}: ${String(err)}`);
       }
+    }
+
+    if (newErrors.length > 0) {
+      setErrors(prev => [...prev, ...newErrors]);
     }
 
     setFiles([]);


### PR DESCRIPTION
## Summary
- allow `handleUpload` to continue on fetch failures
- only show errors after all uploads complete

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68409755fc4c83218b45003b53b619f7